### PR TITLE
Updated README with new Python version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -
 
 ### Prerequisites:
-- Python 3.7 or greater installed
+- Python 3.7-3.10.6 (Python 3.11+ does not work)
 - Install pip(package installer for python)
   - [pip documentation click here](https://pip.pypa.io/en/stable/installation/)
 


### PR DESCRIPTION
Updated README with Python constraints updated to between 3.7 and 3.10.6

People from the SLO software team stated that they have issues getting the GCS API to work when using Python 3.11, and that the issue was resolved when they reverted back to Python 3.10.